### PR TITLE
Fix constant handling in eval_expr

### DIFF
--- a/athenakit/utils/evaluate.py
+++ b/athenakit/utils/evaluate.py
@@ -28,8 +28,12 @@ def eval_expr(expr, func):
         TypeError: If the expression contains unsupported operations.
     """
     def _eval(node):
-        if isinstance(node, ast.Num):  # <number>
+        if isinstance(node, ast.Num):  # <number> (Python <3.8)
             return node.n
+        elif isinstance(node, ast.Constant):  # <number> for Python >=3.8
+            if isinstance(node.value, (int, float)):
+                return node.value
+            raise TypeError(f"Unsupported constant: {node.value}")
         elif isinstance(node, ast.BinOp):  # <left> <operator> <right>
             left = _eval(node.left)
             right = _eval(node.right)


### PR DESCRIPTION
## Summary
- support Python 3.8+ AST changes in `eval_expr`

## Testing
- `python3 -m py_compile athenakit/utils/evaluate.py`

------
https://chatgpt.com/codex/tasks/task_e_684b22822e5c8324b8895d012e3b3dbb