### PR TITLE
Improve documentation and add usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ Current features are:
 ## Getting started
 
 Documentation is under construction on the [wiki](https://github.com/mh-guo/AthenaKit/wiki) pages.
+
+## Basic Usage
+
+The `examples` directory contains short scripts demonstrating common tasks.
+To convert binary dumps to ATHDF format and read a history file:
+
+```bash
+python examples/basic_usage.py /path/to/run
+```
+
+This will create `.athdf` files next to the binaries and print the time
+column from the corresponding history file.

--- a/athenakit/app/acc.py
+++ b/athenakit/app/acc.py
@@ -1,3 +1,6 @@
+"""
+Accretion flow initial condition solver and utilities.
+"""
 import numpy as np
 try:
     import cupy as xp
@@ -37,6 +40,12 @@ n_t_i_ratio=n_t_h_ratio/n_i_h_ratio
 ##############################################################
 
 class InitialCondition:
+    """Solve a spherically symmetric accretion profile.
+
+    The class provides routines to integrate a density profile for a
+    black hole surrounded by stellar and dark matter components using a
+    Runge--Kutta solver.
+    """
     def __init__(self,m_bh,m_star,r_star,m_dm,r_dm,r_entropy,k_entropy,xi_entropy,x_0,dens_0,
                  gamma=5.0/3.0,unit=grunit) -> None:
         self.m_bh=m_bh
@@ -55,8 +64,10 @@ class InitialCondition:
         pass
     # profile solver
     def NFWMass(self,r,ms,rs):
+        """Enclosed mass of an NFW profile."""
         return ms*(np.log(1+r/rs)-r/(rs+r))
     def NFWDens(self,r,ms,rs):
+        """Density of an NFW profile."""
         return ms/(4*np.pi*rs**2*r*(1+r/rs)**2)
     def StellarMass(self,r):
         return self.NFWMass(r,self.m_star,self.r_star)
@@ -90,6 +101,7 @@ class InitialCondition:
         y+=1/6*(k1+2*k2+2*k3+k4)*h
         return y
     def solve(self,x0=None,dens0=None,N1=2048,N2=1024,logh=0.002):
+        """Integrate the accretion profile and return derived quantities."""
         if x0 is None:
             x0 = self.x_0
         if dens0 is None:
@@ -151,6 +163,7 @@ class InitialCondition:
         return self.rs[key]
 
 def add_tools(ad):
+    """Attach commonly used physical quantities to an ``AthenaBinary`` object."""
     ad.rin = ad.header('problem','r_in',float)
     ad.rmin = ad.mb_dx.min()
     ad.rmax = float(np.min(np.abs([ad.x1min,ad.x1max,ad.x2min,ad.x2max,ad.x3min,ad.x3max])))

--- a/athenakit/global_vars.py
+++ b/athenakit/global_vars.py
@@ -1,3 +1,6 @@
+"""
+Detect optional dependencies such as CuPy and MPI.
+"""
 ### global variables ###
 
 cupy_enabled = False

--- a/athenakit/kit.py
+++ b/athenakit/kit.py
@@ -1,3 +1,9 @@
+"""
+Utility functions for converting AthenaK outputs and performing basic analysis.
+
+This module collects helpers for converting binary dumps to ATHDF format,
+loading history files, and common mathematical utilities.
+"""
 import os
 from time import sleep
 import numpy as np
@@ -17,6 +23,7 @@ from scipy.interpolate import interp1d as sp_interp1d
 from . import io
 
 def zeros_like(obj):
+    """Recursively create zero-filled structures matching ``obj``."""
     if (type(obj) is dict):
         return {k:zeros_like(v) for k,v in obj.items()}
     if (type(obj) is list):
@@ -26,6 +33,7 @@ def zeros_like(obj):
     return np.zeros_like(obj)
 
 def plus(a,b):
+    """Add structures ``a`` and ``b`` element-wise."""
     if (type(a) is dict):
         return {k:plus(a[k],b[k]) for k in a.keys()}
     if (type(a) is list):
@@ -35,6 +43,7 @@ def plus(a,b):
     return a+b
 
 def times(a,b):
+    """Multiply structure ``a`` by scalar ``b`` element-wise."""
     if (type(a) is dict):
         return {k:times(a[k],b) for k in a.keys()}
     if (type(a) is list):
@@ -45,6 +54,15 @@ def times(a,b):
 
 # Convert all binary files in binary path to athdf files in athdf path
 def bin_to_athdf(binary_fname,athdf_fname):
+    """Convert a single AthenaK binary output to ``.athdf`` format.
+
+    Parameters
+    ----------
+    binary_fname : str
+        Path to the input ``.bin`` file produced by AthenaK.
+    athdf_fname : str
+        Destination filename for the converted ``.athdf`` file.
+    """
     xdmf_fname = athdf_fname + ".xdmf"
     filedata = io.read_binary(binary_fname)
     io.write_athdf(athdf_fname, filedata)
@@ -52,6 +70,19 @@ def bin_to_athdf(binary_fname,athdf_fname):
     return
 
 def bins_to_athdfs(binpath,athdfpath,overwrite=False,info=True):
+    """Batch convert a directory of ``.bin`` files to ``.athdf`` files.
+
+    Parameters
+    ----------
+    binpath : str
+        Directory containing AthenaK ``.bin`` dumps.
+    athdfpath : str
+        Output directory for ``.athdf`` files.
+    overwrite : bool, optional
+        If ``True`` existing files will be replaced.
+    info : bool, optional
+        Print progress information when ``True``.
+    """
     if not os.path.isdir(athdfpath):
         os.mkdir(athdfpath)
     for file in sorted(os.listdir(binpath)):

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+from athenakit import io, kit
+
+
+def main(run_dir: Path) -> None:
+    """Demonstrate basic conversion and history loading."""
+    bin_dir = run_dir / "bin"
+    athdf_dir = run_dir / "athdf"
+    athdf_dir.mkdir(exist_ok=True)
+
+    # Convert all binary dumps
+    kit.bins_to_athdfs(str(bin_dir), str(athdf_dir), info=True)
+
+    # Read and print history time column
+    hist_file = run_dir / "hist" / "history.hst"
+    if hist_file.exists():
+        hist = io.athena_read.hst(str(hist_file))
+        print("Time steps:", hist["time"])
+    else:
+        print(f"History file {hist_file} not found")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python basic_usage.py <run_directory>")
+    else:
+        main(Path(sys.argv[1]))


### PR DESCRIPTION
## Summary
- document utility module `kit` and add helper docstrings
- document accretion solver and helpers in `athenakit/app/acc.py`
- add description of optional dependency detection in `global_vars`
- expand README with a basic usage section
- provide `examples/basic_usage.py` script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b22e0530c8324beaf01ea57afa2f7